### PR TITLE
HttpExceptionInterface http code resolving & error render event

### DIFF
--- a/classes/ApiErrorHandler.php
+++ b/classes/ApiErrorHandler.php
@@ -10,6 +10,7 @@ use Throwable;
  * Class ApiErrorRenderer
  */
 class ApiErrorHandler {
+    public const ON_RENDER_EVENT = 'octobro.api.onRenderApiError';
 
     /**
      * Simple error handling: wrap an error in array for any error/exception to be rendered in same structure
@@ -36,6 +37,8 @@ class ApiErrorHandler {
             $error['trace'] = explode("\n", $e->getTraceAsString());
         }
 
+        \Event::fire(static::ON_RENDER_EVENT, [&$error, $e], true);
+
         // put under 'errors' key and return
         return [
             'errors' => $error
@@ -55,6 +58,12 @@ class ApiErrorHandler {
             return $e->getStatusCode();
         }
 
-        return $e->getCode() ?? 500;
+        $code = $e->getCode() ?? 500;
+
+        if ($code >= 400 && $code < 500) {
+            return $code;
+        }
+
+        return 500;
     }
 }

--- a/classes/ApiErrorHandler.php
+++ b/classes/ApiErrorHandler.php
@@ -3,6 +3,7 @@
 namespace Octobro\API\Classes;
 
 use Config;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Throwable;
 
 /**
@@ -20,7 +21,7 @@ class ApiErrorHandler {
     {
         $error = [
             'code' => 'INTERNAL_ERROR: ' . class_basename($e),
-            'http_code' => $e->getCode() ?? 500,
+            'http_code' => $this->resolveStatusCode($e),
             'message' => $e->getMessage(),
         ];
 
@@ -39,5 +40,21 @@ class ApiErrorHandler {
         return [
             'errors' => $error
         ];
+    }
+
+    /**
+     * Resolve HTTP status code
+     *
+     * @param Throwable $e
+     *
+     * @return int
+     */
+    protected function resolveStatusCode(Throwable $e): int
+    {
+        if ($e instanceof HttpExceptionInterface) {
+            return $e->getStatusCode();
+        }
+
+        return $e->getCode() ?? 500;
     }
 }


### PR DESCRIPTION
1. Take HTTP code from `getStatusCode()` if exception belongs to `HttpExceptionInterface`
2. emit event `octobro.api.onRenderApiError` after exception is rendered